### PR TITLE
Remove sv-svfactor

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -144,7 +144,6 @@ jobs:
           echo "packages: $GITHUB_WORKSPACE/source/./examples" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/./sv-cassava" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/./sv-core" >> cabal.project
-          echo "packages: $GITHUB_WORKSPACE/source/./sv-svfactor" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/./weigh" >> cabal.project
           cat cabal.project
       - name: sdist
@@ -167,8 +166,6 @@ jobs:
           echo "PKGDIR_sv_cassava=${PKGDIR_sv_cassava}" >> "$GITHUB_ENV"
           PKGDIR_sv_core="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/sv-core-[0-9.]*')"
           echo "PKGDIR_sv_core=${PKGDIR_sv_core}" >> "$GITHUB_ENV"
-          PKGDIR_sv_svfactor="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/sv-svfactor-[0-9.]*')"
-          echo "PKGDIR_sv_svfactor=${PKGDIR_sv_svfactor}" >> "$GITHUB_ENV"
           PKGDIR_sv_weigh="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/sv-weigh-[0-9.]*')"
           echo "PKGDIR_sv_weigh=${PKGDIR_sv_weigh}" >> "$GITHUB_ENV"
           rm -f cabal.project cabal.project.local
@@ -179,7 +176,6 @@ jobs:
           echo "packages: ${PKGDIR_sv_examples}" >> cabal.project
           echo "packages: ${PKGDIR_sv_cassava}" >> cabal.project
           echo "packages: ${PKGDIR_sv_core}" >> cabal.project
-          echo "packages: ${PKGDIR_sv_svfactor}" >> cabal.project
           echo "packages: ${PKGDIR_sv_weigh}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package sv" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
@@ -191,14 +187,12 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package sv-core" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package sv-svfactor" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package sv-weigh" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           optimization: 2
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(sv|sv-benchmarks|sv-cassava|sv-core|sv-examples|sv-svfactor|sv-weigh)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(sv|sv-benchmarks|sv-cassava|sv-core|sv-examples|sv-weigh)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -235,8 +229,6 @@ jobs:
           cd ${PKGDIR_sv_cassava} || false
           ${CABAL} -vnormal check
           cd ${PKGDIR_sv_core} || false
-          ${CABAL} -vnormal check
-          cd ${PKGDIR_sv_svfactor} || false
           ${CABAL} -vnormal check
           cd ${PKGDIR_sv_weigh} || false
           ${CABAL} -vnormal check

--- a/benchmarks/sv-benchmarks.cabal
+++ b/benchmarks/sv-benchmarks.cabal
@@ -29,18 +29,18 @@ library
   other-modules:       Data.Sv.Alien.Hedgehog
   -- other-extensions:    
   build-depends:       base >= 4.9 && < 5
-                       , bytestring >= 0.9.1.10 && < 0.11
+                       , bytestring >= 0.9.1.10 && < 0.12
                        , cassava >= 0.4.1 && < 0.6
                        , contravariant >= 1.2 && < 1.6
                        , deepseq >= 1.1 && < 1.5
                        , directory >= 1.2.1 && < 1.4
                        , hedgehog >= 1 && < 1.1
-                       , lens >= 4 && < 5
+                       , lens >= 4 && < 5.1
                        , semigroups >= 0.18 && < 0.20
                        , semigroupoids >= 5 && < 6
                        , sv == 1.4.*
                        , text >= 1.0 && < 1.3
-                       , transformers >= 0.2 && < 0.6
+                       , transformers >= 0.2 && < 0.7
                        , vector >= 0.10 && < 0.13
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -54,14 +54,14 @@ benchmark criterion
   default-language:
                        Haskell2010
   build-depends:
-                         attoparsec >= 0.12.1.4 && < 0.14
+                         attoparsec >= 0.12.1.4 && < 0.15
                        , base >=4.9 && <5
-                       , bytestring >= 0.9.1.10 && < 0.11
+                       , bytestring >= 0.9.1.10 && < 0.12
                        , cassava >= 0.4.1 && < 0.6
                        , criterion >= 1.3 && < 1.6
                        , deepseq >= 1.1 && < 1.5
                        , hw-dsv >= 0.4 && < 0.5
-                       , lens >= 4 && < 5
+                       , lens >= 4 && < 5.1
                        , sv
                        , sv-benchmarks
                        , sv-cassava == 0.3.*

--- a/cabal.project
+++ b/cabal.project
@@ -4,7 +4,6 @@ packages:
   ./examples
   ./sv-cassava
   ./sv-core
-  ./sv-svfactor
   ./weigh
 
 optimization: 2

--- a/examples/sv-examples.cabal
+++ b/examples/sv-examples.cabal
@@ -35,14 +35,14 @@ library
                        , Data.Sv.Example.TableTennis
   build-depends:       base >= 4.9 && < 5
                        , sv
-                       , bytestring >= 0.9.1.10 && < 0.11
+                       , bytestring >= 0.9.1.10 && < 0.12
                        , contravariant-extras >= 0.3 && < 0.4
-                       , lens >= 4 && < 5
+                       , lens >= 4 && < 5.1
                        , parsers >= 0.12 && <0.13
                        , semigroups >= 0.18 && < 0.20
                        , semigroupoids >= 5 && <6
                        , text >= 1.0 && < 1.3
-                       , time >= 1.5 && < 1.10
+                       , time >= 1.5 && < 1.13
                        , trifecta >= 1.5 && < 2.2
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/sv-cassava/sv-cassava.cabal
+++ b/sv-cassava/sv-cassava.cabal
@@ -33,9 +33,9 @@ library
   exposed-modules:
     Data.Sv.Cassava
   build-depends:
-    attoparsec >= 0.12.1.4 && < 0.14
+    attoparsec >= 0.12.1.4 && < 0.15
     , base >=4.9 && < 4.15
-    , bytestring >= 0.9.1.10 && < 0.11
+    , bytestring >= 0.9.1.10 && < 0.12
     , cassava >= 0.4.1 && < 0.6
     , sv-core >= 0.3 && < 0.6
     , utf8-string >= 1 && < 1.1
@@ -55,7 +55,7 @@ test-suite hunit
     Haskell2010
   build-depends:
     base >=4.9 && < 4.15
-    , bytestring >= 0.9.1.10 && < 0.11
+    , bytestring >= 0.9.1.10 && < 0.12
     , cassava >= 0.4.1 && < 0.6
     , sv-core >= 0.3 && < 0.6
     , sv-cassava

--- a/sv-core/sv-core.cabal
+++ b/sv-core/sv-core.cabal
@@ -49,23 +49,23 @@ library
                        , Data.Sv.Encode.Type
   other-modules:       Data.Sv.Alien.Containers
   -- other-extensions:    
-  build-depends:       attoparsec >= 0.12.1.4 && < 0.14
+  build-depends:       attoparsec >= 0.12.1.4 && < 0.15
                        , base >=4.9 && < 4.15
                        , bifunctors >= 5.1 && < 5.6
-                       , bytestring >= 0.9.1.10 && < 0.11
+                       , bytestring >= 0.9.1.10 && < 0.12
                        , containers >= 0.4 && < 0.7
                        , contravariant >= 1.2 && < 1.6
                        , deepseq >= 1.1 && < 1.5
                        , double-conversion >= 2 && < 2.1
-                       , lens >= 4 && < 4.20
+                       , lens >= 4 && < 5.1
                        , mtl >= 2.0.1 && < 2.3
                        , parsec >= 3.1 && < 3.2
-                       , profunctors >= 5.2.1 && < 5.6
+                       , profunctors >= 5.2.1 && < 5.7
                        , readable >= 0.3 && < 0.4
                        , semigroupoids >= 5 && < 5.4
                        , semigroups >= 0.18 && < 0.20
                        , text >= 1.0 && < 1.3
-                       , transformers >= 0.2 && < 0.6
+                       , transformers >= 0.2 && < 0.7
                        , trifecta >= 1.5 && < 2.2
                        , utf8-string >= 1 && < 1.1
                        , validation >= 1 && < 1.2
@@ -87,12 +87,12 @@ test-suite             tasty
                        Haskell2010
   build-depends:
                        base >=4.9 && < 4.15
-                       , bytestring >= 0.9.1.10 && < 0.11
+                       , bytestring >= 0.9.1.10 && < 0.12
                        , semigroupoids >= 5 && < 5.4
                        , sv-core
-                       , profunctors >= 5 && < 5.6
+                       , profunctors >= 5 && < 5.7
                        , semigroups >= 0.18 && < 0.20
-                       , tasty >= 0.11 && < 1.3
+                       , tasty >= 0.11 && < 1.5
                        , tasty-quickcheck >= 0.9 && < 0.11
                        , text >= 1.0 && < 1.3
                        , validation >= 1 && < 1.2

--- a/sv-svfactor/sv-svfactor.cabal
+++ b/sv-svfactor/sv-svfactor.cabal
@@ -35,9 +35,9 @@ library
   -- other-modules:
   -- other-extensions:    
   build-depends:       base >=4.7 && < 4.15
-                       , bytestring >= 0.9.1.10 && < 0.11
-                       , lens >= 4 && < 4.20
-                       , profunctors >= 5.2.1 && < 5.6
+                       , bytestring >= 0.9.1.10 && < 0.12
+                       , lens >= 4 && < 5.1
+                       , profunctors >= 5.2.1 && < 5.7
                        , sv-core >= 0.3 && < 0.6
                        , svfactor >= 0.1 && < 0.2
                        , validation >= 1 && < 1.2

--- a/sv/sv.cabal
+++ b/sv/sv.cabal
@@ -93,14 +93,14 @@ library
   other-modules:       Data.Sv.Alien.Cassava
   -- other-extensions:    
   build-depends:       base >=4.9 && < 4.15
-                       , attoparsec >= 0.12.1.4 && < 0.14
+                       , attoparsec >= 0.12.1.4 && < 0.15
                        , bifunctors >= 5.1 && < 5.6
-                       , bytestring >= 0.9.1.10 && < 0.11
+                       , bytestring >= 0.9.1.10 && < 0.12
                        , contravariant >= 1.2 && < 1.6
                        , hw-dsv >= 0.4 && < 0.5
                        , semigroupoids >= 5 && < 5.4
                        , sv-core == 0.5.*
-                       , transformers >= 0.2 && < 0.6
+                       , transformers >= 0.2 && < 0.7
                        , utf8-string >= 1 && < 1.1
                        , validation >= 1 && < 1.2
   hs-source-dirs:      src
@@ -122,18 +122,18 @@ test-suite             tasty
                        Haskell2010
   build-depends:
                        base >=4.9 && < 4.15
-                       , bytestring >= 0.9.1.10 && < 0.11
+                       , bytestring >= 0.9.1.10 && < 0.12
                        , cassava >= 0.4.1 && < 0.6
                        , contravariant >= 1.2 && < 1.6
                        , hedgehog >= 0.5 && < 1.1
-                       , lens >= 4 && < 4.20
+                       , lens >= 4 && < 5.1
                        , parsers >=0.12 && <0.13
                        , Only >= 0.1 && < 0.2
                        , semigroupoids >= 5 && < 5.4
                        , semigroups >= 0.18 && < 0.20
                        , sv
-                       , tasty >= 0.11 && < 1.3
-                       , tasty-hedgehog >= 0.1 && < 1.1
+                       , tasty >= 0.11 && < 1.5
+                       , tasty-hedgehog >= 0.1 && < 1.2
                        , tasty-hunit >= 0.9 && < 0.11
                        , text >= 1.0 && < 1.3
                        , trifecta >= 1.5 && < 2.2
@@ -153,13 +153,13 @@ benchmark criterion
   default-language:
                        Haskell2010
   build-depends:
-                         attoparsec >= 0.12.1.4 && < 0.14
+                         attoparsec >= 0.12.1.4 && < 0.15
                        , base >=4.9 && < 4.15
-                       , bytestring >= 0.9.1.10 && < 0.11
+                       , bytestring >= 0.9.1.10 && < 0.12
                        , criterion >= 1.3 && < 1.6
                        , deepseq >= 1.1 && < 1.5
                        , hw-dsv >= 0.4 && < 0.5
-                       , lens >= 4 && < 4.20
+                       , lens >= 4 && < 5.1
                        , sv
                        , text >= 1.0 && < 1.3
                        , vector >= 0.10 && < 0.13

--- a/weigh/sv-weigh.cabal
+++ b/weigh/sv-weigh.cabal
@@ -29,7 +29,7 @@ executable sv-weigh
   -- other-extensions:
   build-depends:
       base >=4.9 && <4.15
-    , bytestring >= 0.9.1.10 && < 0.11
+    , bytestring >= 0.9.1.10 && < 0.12
     , directory >= 1.2 && < 1.4
     , sv == 1.4.*
     , weigh >= 0.0.12 && < 0.1


### PR DESCRIPTION
I don't intend to maintain it any longer. It can stay in the tree for a while though, in case somebody changes my mind. This just removes it from the cabal.project.
I've also updated dependencies.