### PR TITLE
Introduce optionalColumn for implementing backwards compatible parsers

### DIFF
--- a/sv-core/src/Data/Sv/Decode/Core.hs
+++ b/sv-core/src/Data/Sv/Decode/Core.hs
@@ -595,7 +595,7 @@ infixl 5 .:
 -- useful for backwards compatible decoders.
 optionalColumn :: Ord s => s -> Decode' s a -> NameDecode' s (Maybe a)
 optionalColumn s d =
-  Named . ReaderT $ \m -> case Map.lookup s m of
+  Named . ReaderT $ \m -> case M.lookup s m of
     Nothing -> pure Nothing
     Just i -> Compose . pure . buildDecode $ \vec _ ->
       case runDecode d vec i of


### PR DESCRIPTION
Adds
```
optionalColumn :: Ord s => s -> Decode' s a -> NameDecode' s (Maybe a)
```
and a corresponding infix version `(.?)` to complement the existing `column` and `(.:)`.

I couldn't see an easy way to share code between `column` and `optionalColumn`, so copy-paste it is...